### PR TITLE
update ignorecase option

### DIFF
--- a/autoload/unite/sources/cmdmatch.vim
+++ b/autoload/unite/sources/cmdmatch.vim
@@ -56,6 +56,6 @@ fu! unite#sources#cmdmatch#define()
   retu s:unite_source
 endf
 
-call unite#custom#profile('source/common', 'ignorecase', 1)
+call unite#custom#profile('source/common', 'context.ignorecase', 1)
 "call unite#custom#source('cmdmatch', 'filters',['matcher_fuzzy'])
 


### PR DESCRIPTION
unite.vim updated the name of its settings, which causes an error message on vim startup if this plugin is sourced. this simple update fixes that.
